### PR TITLE
Add successful commit status to autoformatter

### DIFF
--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -23,3 +23,6 @@ jobs:
           add: "*.java"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ouzi-dev/commit-status-updater@v1.0.4
+        with:
+          status: "success"


### PR DESCRIPTION
As of now, the changes the autoformatter commits are passing the Google CLA check but they're not triggering the unit test check for some reason. It's also a bit strange because it's not failing these checks either; they're simply not happening. I added something in the javalint workflow that adds a successful commit status to the formatter commits which can serve as a quick fix so that I'm able to merge the sentiment pr but I'm not sure if it's the best solution. 